### PR TITLE
fix: Knitting does not use renv same way as r standard

### DIFF
--- a/Monthly Projections.Rmd
+++ b/Monthly Projections.Rmd
@@ -36,7 +36,7 @@ knitr::opts_knit$set(progress = TRUE, verbose = TRUE)
 # params$reporting_path <- gsub("\\","/", params$reporting_path, fixed = TRUE) # platform independent
 print(params$debug)
 # running as R works fine, but knitting fails without this line below
-pacman::p_load("dplyr","lubridate")
+pacman::p_load("dplyr", "lubridate")
 ```
 
 ## Monthly Projections


### PR DESCRIPTION
# Description
Allow knitting of our R-Markdown files immediately upon cloning a repository.

## Motivation and Context
R-Markdown files don't seem to systematically rely on renv as much as standard R code does.  When running as knitting often get errors regarding missing functions or functions not identifiable from packages loaded.

## Breaking Changes
None

## How Has This Been Tested?
Reran last reporting period and validated results.