### PR TITLE
chore: Minor updates for 2025Q3

### DIFF
--- a/Monthly Projections.Rmd
+++ b/Monthly Projections.Rmd
@@ -18,11 +18,11 @@ params:
   date_of_valuation:
     input: date
     label: Date of Valuation
-    value: "2025-06-30"
+    value: "2025-09-30"
   reporting_path:
     input: text
     label: Working directory for the monthly valuation process
-    value:
+    value: !r getwd()
   inputs_workbook:
     input: text
     label: Workbook Containing All Inputs Required for this process
@@ -36,6 +36,7 @@ knitr::opts_knit$set(progress = TRUE, verbose = TRUE)
 # params$reporting_path <- gsub("\\","/", params$reporting_path, fixed = TRUE) # platform independent
 print(params$debug)
 # running as R works fine, but knitting fails without this line below
+renv::activate()
 pacman::p_load("dplyr", "lubridate")
 ```
 
@@ -47,7 +48,7 @@ pacman::p_load("dplyr", "lubridate")
 # set.seed(params$prng_seed) # seed the random number generator
 # prevent scientific notation for cross-platform compatibility
 options(scipen = 999)
-
+renv::status()
 proj.env$time_begin <- Sys.time()
 ```
 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.1",
+    "Version": "4.3.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -410,6 +410,20 @@
       ],
       "Hash": "0dae94b258dc5abc4713eacdbbebcb51"
     },
+    "pacman": {
+      "Package": "pacman",
+      "Version": "0.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "remotes",
+        "stats",
+        "utils"
+      ],
+      "Hash": "b37932b67288bc62bb81686b2f337a7d"
+    },
     "pillar": {
       "Package": "pillar",
       "Version": "1.9.0",
@@ -523,6 +537,20 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "cbff1b666c6fa6d21202f07e2318d4f1"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3ee025083e66f18db6cf27b56e23e141"
     },
     "renv": {
       "Package": "renv",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -97,24 +97,24 @@ local({
   if ("renv" %in% loadedNamespaces())
     unloadNamespace("renv")
 
-  # load bootstrap tools
+  # load bootstrap tools   
   `%||%` <- function(x, y) {
     if (is.null(x)) y else x
   }
-
+  
   catf <- function(fmt, ..., appendLF = TRUE) {
-
+  
     quiet <- getOption("renv.bootstrap.quiet", default = FALSE)
     if (quiet)
       return(invisible())
-
+  
     msg <- sprintf(fmt, ...)
     cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
-
+  
     invisible(msg)
-
+  
   }
-
+  
   header <- function(label,
                      ...,
                      prefix = "#",
@@ -125,37 +125,37 @@ local({
     n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
     if (n <= 0)
       return(paste(prefix, label))
-
+  
     tail <- paste(rep.int(suffix, n), collapse = "")
     paste0(prefix, " ", label, " ", tail)
-
+  
   }
-
+  
   heredoc <- function(text, leave = 0) {
-
+  
     # remove leading, trailing whitespace
     trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
-
+  
     # split into lines
     lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
-
+  
     # compute common indent
     indent <- regexpr("[^[:space:]]", lines)
     common <- min(setdiff(indent, -1L)) - leave
     paste(substring(lines, common), collapse = "\n")
-
+  
   }
-
+  
   startswith <- function(string, prefix) {
     substring(string, 1, nchar(prefix)) == prefix
   }
-
+  
   bootstrap <- function(version, library) {
-
+  
     friendly <- renv_bootstrap_version_friendly(version)
     section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
-
+  
     # attempt to download renv
     catf("- Downloading renv ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -167,7 +167,7 @@ local({
     )
     catf("OK")
     on.exit(unlink(tarball), add = TRUE)
-
+  
     # now attempt to install
     catf("- Installing renv  ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -178,174 +178,174 @@ local({
       }
     )
     catf("OK")
-
+  
     # add empty line to break up bootstrapping from normal output
     catf("")
-
+  
     return(invisible())
   }
-
+  
   renv_bootstrap_tests_running <- function() {
     getOption("renv.tests.running", default = FALSE)
   }
-
+  
   renv_bootstrap_repos <- function() {
-
+  
     # get CRAN repository
     cran <- getOption("renv.repos.cran", "https://cloud.r-project.org")
-
+  
     # check for repos override
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
     if (!is.na(repos)) {
-
+  
       # check for RSPM; if set, use a fallback repository for renv
       rspm <- Sys.getenv("RSPM", unset = NA)
       if (identical(rspm, repos))
         repos <- c(RSPM = rspm, CRAN = cran)
-
+  
       return(repos)
-
+  
     }
-
+  
     # check for lockfile repositories
     repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
     if (!inherits(repos, "error") && length(repos))
       return(repos)
-
+  
     # retrieve current repos
     repos <- getOption("repos")
-
+  
     # ensure @CRAN@ entries are resolved
     repos[repos == "@CRAN@"] <- cran
-
+  
     # add in renv.bootstrap.repos if set
     default <- c(FALLBACK = "https://cloud.r-project.org")
     extra <- getOption("renv.bootstrap.repos", default = default)
     repos <- c(repos, extra)
-
+  
     # remove duplicates that might've snuck in
     dupes <- duplicated(repos) | duplicated(names(repos))
     repos[!dupes]
-
+  
   }
-
+  
   renv_bootstrap_repos_lockfile <- function() {
-
+  
     lockpath <- Sys.getenv("RENV_PATHS_LOCKFILE", unset = "renv.lock")
     if (!file.exists(lockpath))
       return(NULL)
-
+  
     lockfile <- tryCatch(renv_json_read(lockpath), error = identity)
     if (inherits(lockfile, "error")) {
       warning(lockfile)
       return(NULL)
     }
-
+  
     repos <- lockfile$R$Repositories
     if (length(repos) == 0)
       return(NULL)
-
+  
     keys <- vapply(repos, `[[`, "Name", FUN.VALUE = character(1))
     vals <- vapply(repos, `[[`, "URL", FUN.VALUE = character(1))
     names(vals) <- keys
-
+  
     return(vals)
-
+  
   }
-
+  
   renv_bootstrap_download <- function(version) {
-
+  
     sha <- attr(version, "sha", exact = TRUE)
-
+  
     methods <- if (!is.null(sha)) {
-
+  
       # attempting to bootstrap a development version of renv
       c(
         function() renv_bootstrap_download_tarball(sha),
         function() renv_bootstrap_download_github(sha)
       )
-
+  
     } else {
-
+  
       # attempting to bootstrap a release version of renv
       c(
         function() renv_bootstrap_download_tarball(version),
         function() renv_bootstrap_download_cran_latest(version),
         function() renv_bootstrap_download_cran_archive(version)
       )
-
+  
     }
-
+  
     for (method in methods) {
       path <- tryCatch(method(), error = identity)
       if (is.character(path) && file.exists(path))
         return(path)
     }
-
+  
     stop("All download methods failed")
-
+  
   }
-
+  
   renv_bootstrap_download_impl <- function(url, destfile) {
-
+  
     mode <- "wb"
-
+  
     # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
     fixup <-
       Sys.info()[["sysname"]] == "Windows" &&
       substring(url, 1L, 5L) == "file:"
-
+  
     if (fixup)
       mode <- "w+b"
-
+  
     args <- list(
       url      = url,
       destfile = destfile,
       mode     = mode,
       quiet    = TRUE
     )
-
+  
     if ("headers" %in% names(formals(utils::download.file)))
       args$headers <- renv_bootstrap_download_custom_headers(url)
-
+  
     do.call(utils::download.file, args)
-
+  
   }
-
+  
   renv_bootstrap_download_custom_headers <- function(url) {
-
+  
     headers <- getOption("renv.download.headers")
     if (is.null(headers))
       return(character())
-
+  
     if (!is.function(headers))
       stopf("'renv.download.headers' is not a function")
-
+  
     headers <- headers(url)
     if (length(headers) == 0L)
       return(character())
-
+  
     if (is.list(headers))
       headers <- unlist(headers, recursive = FALSE, use.names = TRUE)
-
+  
     ok <-
       is.character(headers) &&
       is.character(names(headers)) &&
       all(nzchar(names(headers)))
-
+  
     if (!ok)
       stop("invocation of 'renv.download.headers' did not return a named character vector")
-
+  
     headers
-
+  
   }
-
+  
   renv_bootstrap_download_cran_latest <- function(version) {
-
+  
     spec <- renv_bootstrap_download_cran_latest_find(version)
     type  <- spec$type
     repos <- spec$repos
-
+  
     baseurl <- utils::contrib.url(repos = repos, type = type)
     ext <- if (identical(type, "source"))
       ".tar.gz"
@@ -355,36 +355,36 @@ local({
       ".tgz"
     name <- sprintf("renv_%s%s", version, ext)
     url <- paste(baseurl, name, sep = "/")
-
+  
     destfile <- file.path(tempdir(), name)
     status <- tryCatch(
       renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
-
+  
     if (inherits(status, "condition"))
       return(FALSE)
-
+  
     # report success and return
     destfile
-
+  
   }
-
+  
   renv_bootstrap_download_cran_latest_find <- function(version) {
-
+  
     # check whether binaries are supported on this system
     binary <-
       getOption("renv.bootstrap.binary", default = TRUE) &&
       !identical(.Platform$pkgType, "source") &&
       !identical(getOption("pkgType"), "source") &&
       Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
-
+  
     types <- c(if (binary) "binary", "source")
-
+  
     # iterate over types + repositories
     for (type in types) {
       for (repos in renv_bootstrap_repos()) {
-
+  
         # retrieve package database
         db <- tryCatch(
           as.data.frame(
@@ -393,89 +393,89 @@ local({
           ),
           error = identity
         )
-
+  
         if (inherits(db, "error"))
           next
-
+  
         # check for compatible entry
         entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
         if (nrow(entry) == 0)
           next
-
+  
         # found it; return spec to caller
         spec <- list(entry = entry, type = type, repos = repos)
         return(spec)
-
+  
       }
     }
-
+  
     # if we got here, we failed to find renv
     fmt <- "renv %s is not available from your declared package repositories"
     stop(sprintf(fmt, version))
-
+  
   }
-
+  
   renv_bootstrap_download_cran_archive <- function(version) {
-
+  
     name <- sprintf("renv_%s.tar.gz", version)
     repos <- renv_bootstrap_repos()
     urls <- file.path(repos, "src/contrib/Archive/renv", name)
     destfile <- file.path(tempdir(), name)
-
+  
     for (url in urls) {
-
+  
       status <- tryCatch(
         renv_bootstrap_download_impl(url, destfile),
         condition = identity
       )
-
+  
       if (identical(status, 0L))
         return(destfile)
-
+  
     }
-
+  
     return(FALSE)
-
+  
   }
-
+  
   renv_bootstrap_download_tarball <- function(version) {
-
+  
     # if the user has provided the path to a tarball via
     # an environment variable, then use it
     tarball <- Sys.getenv("RENV_BOOTSTRAP_TARBALL", unset = NA)
     if (is.na(tarball))
       return()
-
+  
     # allow directories
     if (dir.exists(tarball)) {
       name <- sprintf("renv_%s.tar.gz", version)
       tarball <- file.path(tarball, name)
     }
-
+  
     # bail if it doesn't exist
     if (!file.exists(tarball)) {
-
+  
       # let the user know we weren't able to honour their request
       fmt <- "- RENV_BOOTSTRAP_TARBALL is set (%s) but does not exist."
       msg <- sprintf(fmt, tarball)
       warning(msg)
-
+  
       # bail
       return()
-
+  
     }
-
+  
     catf("- Using local tarball '%s'.", tarball)
     tarball
-
+  
   }
-
+  
   renv_bootstrap_download_github <- function(version) {
-
+  
     enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
     if (!identical(enabled, "TRUE"))
       return(FALSE)
-
+  
     # prepare download options
     pat <- Sys.getenv("GITHUB_PAT")
     if (nzchar(Sys.which("curl")) && nzchar(pat)) {
@@ -491,25 +491,25 @@ local({
       options(download.file.method = "wget", download.file.extra = extra)
       on.exit(do.call(base::options, saved), add = TRUE)
     }
-
+  
     url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
     name <- sprintf("renv_%s.tar.gz", version)
     destfile <- file.path(tempdir(), name)
-
+  
     status <- tryCatch(
       renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
-
+  
     if (!identical(status, 0L))
       return(FALSE)
-
+  
     renv_bootstrap_download_augment(destfile)
-
+  
     return(destfile)
-
+  
   }
-
+  
   # Add Sha to DESCRIPTION. This is stop gap until #890, after which we
   # can use renv::install() to fully capture metadata.
   renv_bootstrap_download_augment <- function(destfile) {
@@ -517,13 +517,13 @@ local({
     if (is.null(sha)) {
       return()
     }
-
+  
     # Untar
     tempdir <- tempfile("renv-github-")
     on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
     untar(destfile, exdir = tempdir)
     pkgdir <- dir(tempdir, full.names = TRUE)[[1]]
-
+  
     # Modify description
     desc_path <- file.path(pkgdir, "DESCRIPTION")
     desc_lines <- readLines(desc_path)
@@ -537,173 +537,173 @@ local({
       paste("RemoteSha: ", sha)
     )
     writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
-
+  
     # Re-tar
     local({
       old <- setwd(tempdir)
       on.exit(setwd(old), add = TRUE)
-
+  
       tar(destfile, compression = "gzip")
     })
     invisible()
   }
-
+  
   # Extract the commit hash from a git archive. Git archives include the SHA1
   # hash as the comment field of the tarball pax extended header
   # (see https://www.kernel.org/pub/software/scm/git/docs/git-archive.html)
   # For GitHub archives this should be the first header after the default one
   # (512 byte) header.
   renv_bootstrap_git_extract_sha1_tar <- function(bundle) {
-
+  
     # open the bundle for reading
     # We use gzcon for everything because (from ?gzcon)
     # > Reading from a connection which does not supply a 'gzip' magic
     # > header is equivalent to reading from the original connection
     conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
     on.exit(close(conn))
-
+  
     # The default pax header is 512 bytes long and the first pax extended header
     # with the comment should be 51 bytes long
     # `52 comment=` (11 chars) + 40 byte SHA1 hash
     len <- 0x200 + 0x33
     res <- rawToChar(readBin(conn, "raw", n = len)[0x201:len])
-
+  
     if (grepl("^52 comment=", res)) {
       sub("52 comment=", "", res)
     } else {
       NULL
     }
   }
-
+  
   renv_bootstrap_install <- function(version, tarball, library) {
-
+  
     # attempt to install it into project library
     dir.create(library, showWarnings = FALSE, recursive = TRUE)
     output <- renv_bootstrap_install_impl(library, tarball)
-
+  
     # check for successful install
     status <- attr(output, "status")
     if (is.null(status) || identical(status, 0L))
       return(status)
-
+  
     # an error occurred; report it
     header <- "installation of renv failed"
     lines <- paste(rep.int("=", nchar(header)), collapse = "")
     text <- paste(c(header, lines, output), collapse = "\n")
     stop(text)
-
+  
   }
-
+  
   renv_bootstrap_install_impl <- function(library, tarball) {
-
+  
     # invoke using system2 so we can capture and report output
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
     R <- file.path(bin, exe)
-
+  
     args <- c(
       "--vanilla", "CMD", "INSTALL", "--no-multiarch",
       "-l", shQuote(path.expand(library)),
       shQuote(path.expand(tarball))
     )
-
+  
     system2(R, args, stdout = TRUE, stderr = TRUE)
-
+  
   }
-
+  
   renv_bootstrap_platform_prefix <- function() {
-
+  
     # construct version prefix
     version <- paste(R.version$major, R.version$minor, sep = ".")
     prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
-
+  
     # include SVN revision for development versions of R
     # (to avoid sharing platform-specific artefacts with released versions of R)
     devel <-
       identical(R.version[["status"]],   "Under development (unstable)") ||
       identical(R.version[["nickname"]], "Unsuffered Consequences")
-
+  
     if (devel)
       prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
-
+  
     # build list of path components
     components <- c(prefix, R.version$platform)
-
+  
     # include prefix if provided by user
     prefix <- renv_bootstrap_platform_prefix_impl()
     if (!is.na(prefix) && nzchar(prefix))
       components <- c(prefix, components)
-
+  
     # build prefix
     paste(components, collapse = "/")
-
+  
   }
-
+  
   renv_bootstrap_platform_prefix_impl <- function() {
-
+  
     # if an explicit prefix has been supplied, use it
     prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
     if (!is.na(prefix))
       return(prefix)
-
+  
     # if the user has requested an automatic prefix, generate it
     auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
     if (is.na(auto) && getRversion() >= "4.4.0")
       auto <- "TRUE"
-
+  
     if (auto %in% c("TRUE", "True", "true", "1"))
       return(renv_bootstrap_platform_prefix_auto())
-
+  
     # empty string on failure
     ""
-
+  
   }
-
+  
   renv_bootstrap_platform_prefix_auto <- function() {
-
+  
     prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
     if (inherits(prefix, "error") || prefix %in% "unknown") {
-
+  
       msg <- paste(
         "failed to infer current operating system",
         "please file a bug report at https://github.com/rstudio/renv/issues",
         sep = "; "
       )
-
+  
       warning(msg)
-
+  
     }
-
+  
     prefix
-
+  
   }
-
+  
   renv_bootstrap_platform_os <- function() {
-
+  
     sysinfo <- Sys.info()
     sysname <- sysinfo[["sysname"]]
-
+  
     # handle Windows + macOS up front
     if (sysname == "Windows")
       return("windows")
     else if (sysname == "Darwin")
       return("macos")
-
+  
     # check for os-release files
     for (file in c("/etc/os-release", "/usr/lib/os-release"))
       if (file.exists(file))
         return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
-
+  
     # check for redhat-release files
     if (file.exists("/etc/redhat-release"))
       return(renv_bootstrap_platform_os_via_redhat_release())
-
+  
     "unknown"
-
+  
   }
-
+  
   renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
-
+  
     # read /etc/os-release
     release <- utils::read.table(
       file             = file,
@@ -713,13 +713,13 @@ local({
       comment.char     = "#",
       stringsAsFactors = FALSE
     )
-
+  
     vars <- as.list(release$Value)
     names(vars) <- release$Key
-
+  
     # get os name
     os <- tolower(sysinfo[["sysname"]])
-
+  
     # read id
     id <- "unknown"
     for (field in c("ID", "ID_LIKE")) {
@@ -728,7 +728,7 @@ local({
         break
       }
     }
-
+  
     # read version
     version <- "unknown"
     for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
@@ -737,17 +737,17 @@ local({
         break
       }
     }
-
+  
     # join together
     paste(c(os, id, version), collapse = "-")
-
+  
   }
-
+  
   renv_bootstrap_platform_os_via_redhat_release <- function() {
-
+  
     # read /etc/redhat-release
     contents <- readLines("/etc/redhat-release", warn = FALSE)
-
+  
     # infer id
     id <- if (grepl("centos", contents, ignore.case = TRUE))
       "centos"
@@ -755,73 +755,73 @@ local({
       "redhat"
     else
       "unknown"
-
+  
     # try to find a version component (very hacky)
     version <- "unknown"
-
+  
     parts <- strsplit(contents, "[[:space:]]")[[1L]]
     for (part in parts) {
-
+  
       nv <- tryCatch(numeric_version(part), error = identity)
       if (inherits(nv, "error"))
         next
-
+  
       version <- nv[1, 1]
       break
-
+  
     }
-
+  
     paste(c("linux", id, version), collapse = "-")
-
+  
   }
-
+  
   renv_bootstrap_library_root_name <- function(project) {
-
+  
     # use project name as-is if requested
     asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
     if (asis)
       return(basename(project))
-
+  
     # otherwise, disambiguate based on project's path
     id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
     paste(basename(project), id, sep = "-")
-
+  
   }
-
+  
   renv_bootstrap_library_root <- function(project) {
-
+  
     prefix <- renv_bootstrap_profile_prefix()
-
+  
     path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
     if (!is.na(path))
       return(paste(c(path, prefix), collapse = "/"))
-
+  
     path <- renv_bootstrap_library_root_impl(project)
     if (!is.null(path)) {
       name <- renv_bootstrap_library_root_name(project)
       return(paste(c(path, prefix, name), collapse = "/"))
     }
-
+  
     renv_bootstrap_paths_renv("library", project = project)
-
+  
   }
-
+  
   renv_bootstrap_library_root_impl <- function(project) {
-
+  
     root <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
     if (!is.na(root))
       return(root)
-
+  
     type <- renv_bootstrap_project_type(project)
     if (identical(type, "package")) {
       userdir <- renv_bootstrap_user_dir()
       return(file.path(userdir, "library"))
     }
-
+  
   }
-
+  
   renv_bootstrap_validate_version <- function(version, description = NULL) {
-
+  
     # resolve description file
     #
     # avoid passing lib.loc to `packageDescription()` below, since R will
@@ -829,17 +829,17 @@ local({
     # this function should only be called after 'renv' is loaded
     # https://github.com/rstudio/renv/issues/1625
     description <- description %||% packageDescription("renv")
-
+  
     # check whether requested version 'version' matches loaded version of renv
     sha <- attr(version, "sha", exact = TRUE)
     valid <- if (!is.null(sha))
       renv_bootstrap_validate_version_dev(sha, description)
     else
       renv_bootstrap_validate_version_release(version, description)
-
+  
     if (valid)
       return(TRUE)
-
+  
     # the loaded version of renv doesn't match the requested version;
     # give the user instructions on how to proceed
     dev <- identical(description[["RemoteType"]], "github")
@@ -847,103 +847,103 @@ local({
       paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
     else
       paste("renv", description[["Version"]], sep = "@")
-
+  
     # display both loaded version + sha if available
     friendly <- renv_bootstrap_version_friendly(
       version = description[["Version"]],
       sha     = if (dev) description[["RemoteSha"]]
     )
-
+  
     fmt <- heredoc("
       renv %1$s was loaded from project library, but this project is configured to use renv %2$s.
       - Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.
       - Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.
     ")
     catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
-
+  
     FALSE
-
+  
   }
-
+  
   renv_bootstrap_validate_version_dev <- function(version, description) {
     expected <- description[["RemoteSha"]]
     is.character(expected) && startswith(expected, version)
   }
-
+  
   renv_bootstrap_validate_version_release <- function(version, description) {
     expected <- description[["Version"]]
     is.character(expected) && identical(expected, version)
   }
-
+  
   renv_bootstrap_hash_text <- function(text) {
-
+  
     hashfile <- tempfile("renv-hash-")
     on.exit(unlink(hashfile), add = TRUE)
-
+  
     writeLines(text, con = hashfile)
     tools::md5sum(hashfile)
-
+  
   }
-
+  
   renv_bootstrap_load <- function(project, libpath, version) {
-
+  
     # try to load renv from the project library
     if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
       return(FALSE)
-
+  
     # warn if the version of renv loaded does not match
     renv_bootstrap_validate_version(version)
-
+  
     # execute renv load hooks, if any
     hooks <- getHook("renv::autoload")
     for (hook in hooks)
       if (is.function(hook))
         tryCatch(hook(), error = warnify)
-
+  
     # load the project
     renv::load(project)
-
+  
     TRUE
-
+  
   }
-
+  
   renv_bootstrap_profile_load <- function(project) {
-
+  
     # if RENV_PROFILE is already set, just use that
     profile <- Sys.getenv("RENV_PROFILE", unset = NA)
     if (!is.na(profile) && nzchar(profile))
       return(profile)
-
+  
     # check for a profile file (nothing to do if it doesn't exist)
     path <- renv_bootstrap_paths_renv("profile", profile = FALSE, project = project)
     if (!file.exists(path))
       return(NULL)
-
+  
     # read the profile, and set it if it exists
     contents <- readLines(path, warn = FALSE)
     if (length(contents) == 0L)
       return(NULL)
-
+  
     # set RENV_PROFILE
     profile <- contents[[1L]]
     if (!profile %in% c("", "default"))
       Sys.setenv(RENV_PROFILE = profile)
-
+  
     profile
-
+  
   }
-
+  
   renv_bootstrap_profile_prefix <- function() {
     profile <- renv_bootstrap_profile_get()
     if (!is.null(profile))
       return(file.path("profiles", profile, "renv"))
   }
-
+  
   renv_bootstrap_profile_get <- function() {
     profile <- Sys.getenv("RENV_PROFILE", unset = "")
     renv_bootstrap_profile_normalize(profile)
   }
-
+  
   renv_bootstrap_profile_set <- function(profile) {
     profile <- renv_bootstrap_profile_normalize(profile)
     if (is.null(profile))
@@ -951,25 +951,25 @@ local({
     else
       Sys.setenv(RENV_PROFILE = profile)
   }
-
+  
   renv_bootstrap_profile_normalize <- function(profile) {
-
+  
     if (is.null(profile) || profile %in% c("", "default"))
       return(NULL)
-
+  
     profile
-
+  
   }
-
+  
   renv_bootstrap_path_absolute <- function(path) {
-
+  
     substr(path, 1L, 1L) %in% c("~", "/", "\\") || (
       substr(path, 1L, 1L) %in% c(letters, LETTERS) &&
       substr(path, 2L, 3L) %in% c(":/", ":\\")
     )
-
+  
   }
-
+  
   renv_bootstrap_paths_renv <- function(..., profile = TRUE, project = NULL) {
     renv <- Sys.getenv("RENV_PATHS_RENV", unset = "renv")
     root <- if (renv_bootstrap_path_absolute(renv)) NULL else project
@@ -977,50 +977,50 @@ local({
     components <- c(root, renv, prefix, ...)
     paste(components, collapse = "/")
   }
-
+  
   renv_bootstrap_project_type <- function(path) {
-
+  
     descpath <- file.path(path, "DESCRIPTION")
     if (!file.exists(descpath))
       return("unknown")
-
+  
     desc <- tryCatch(
       read.dcf(descpath, all = TRUE),
       error = identity
     )
-
+  
     if (inherits(desc, "error"))
       return("unknown")
-
+  
     type <- desc$Type
     if (!is.null(type))
       return(tolower(type))
-
+  
     package <- desc$Package
     if (!is.null(package))
       return("package")
-
+  
     "unknown"
-
+  
   }
-
+  
   renv_bootstrap_user_dir <- function() {
     dir <- renv_bootstrap_user_dir_impl()
     path.expand(chartr("\\", "/", dir))
   }
-
+  
   renv_bootstrap_user_dir_impl <- function() {
-
+  
     # use local override if set
     override <- getOption("renv.userdir.override")
     if (!is.null(override))
       return(override)
-
+  
     # use R_user_dir if available
     tools <- asNamespace("tools")
     if (is.function(tools$R_user_dir))
       return(tools$R_user_dir("renv", "cache"))
-
+  
     # try using our own backfill for older versions of R
     envvars <- c("R_USER_CACHE_DIR", "XDG_CACHE_HOME")
     for (envvar in envvars) {
@@ -1028,7 +1028,7 @@ local({
       if (!is.na(root))
         return(file.path(root, "R/renv"))
     }
-
+  
     # use platform-specific default fallbacks
     if (Sys.info()[["sysname"]] == "Windows")
       file.path(Sys.getenv("LOCALAPPDATA"), "R/cache/R/renv")
@@ -1036,109 +1036,109 @@ local({
       "~/Library/Caches/org.R-project.R/R/renv"
     else
       "~/.cache/R/renv"
-
+  
   }
-
+  
   renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) {
     sha <- sha %||% attr(version, "sha", exact = TRUE)
     parts <- c(version, sprintf(shafmt %||% " [sha: %s]", substring(sha, 1L, 7L)))
     paste(parts, collapse = "")
   }
-
+  
   renv_bootstrap_exec <- function(project, libpath, version) {
     if (!renv_bootstrap_load(project, libpath, version))
       renv_bootstrap_run(version, libpath)
   }
-
+  
   renv_bootstrap_run <- function(version, libpath) {
-
+  
     # perform bootstrap
     bootstrap(version, libpath)
-
+  
     # exit early if we're just testing bootstrap
     if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
       return(TRUE)
-
+  
     # try again to load
     if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
       return(renv::load(project = getwd()))
     }
-
+  
     # failed to download or load renv; warn the user
     msg <- c(
       "Failed to find an renv installation: the project will not be loaded.",
       "Use `renv::activate()` to re-initialize the project."
     )
-
+  
     warning(paste(msg, collapse = "\n"), call. = FALSE)
-
+  
   }
-
+  
   renv_json_read <- function(file = NULL, text = NULL) {
-
+  
     jlerr <- NULL
-
+  
     # if jsonlite is loaded, use that instead
     if ("jsonlite" %in% loadedNamespaces()) {
-
+  
       json <- tryCatch(renv_json_read_jsonlite(file, text), error = identity)
       if (!inherits(json, "error"))
         return(json)
-
+  
       jlerr <- json
-
+  
     }
-
+  
     # otherwise, fall back to the default JSON reader
     json <- tryCatch(renv_json_read_default(file, text), error = identity)
     if (!inherits(json, "error"))
       return(json)
-
+  
     # report an error
     if (!is.null(jlerr))
       stop(jlerr)
     else
       stop(json)
-
+  
   }
-
+  
   renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
     text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
   }
-
+  
   renv_json_read_default <- function(file = NULL, text = NULL) {
-
+  
     # find strings in the JSON
     text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
-
+  
     # if any are found, replace them with placeholders
     replaced <- text
     strings <- character()
     replacements <- character()
-
+  
     if (!identical(c(locs), -1L)) {
-
+  
       # get the string values
       starts <- locs
       ends <- locs + attr(locs, "match.length") - 1L
       strings <- substring(text, starts, ends)
-
+  
       # only keep those requiring escaping
       strings <- grep("[[\\]{}:]", strings, perl = TRUE, value = TRUE)
-
+  
       # compute replacements
       replacements <- sprintf('"\032%i\032"', seq_along(strings))
-
+  
       # replace the strings
       mapply(function(string, replacement) {
         replaced <<- sub(string, replacement, replaced, fixed = TRUE)
       }, strings, replacements)
-
+  
     }
-
+  
     # transform the JSON into something the R parser understands
     transformed <- replaced
     transformed <- gsub("{}", "`names<-`(list(), character())", transformed, fixed = TRUE)
@@ -1146,38 +1146,38 @@ local({
     transformed <- gsub("[]}]", ")", transformed, perl = TRUE)
     transformed <- gsub(":", "=", transformed, fixed = TRUE)
     text <- paste(transformed, collapse = "\n")
-
+  
     # parse it
     json <- parse(text = text, keep.source = FALSE, srcfile = NULL)[[1L]]
-
+  
     # construct map between source strings, replaced strings
     map <- as.character(parse(text = strings))
     names(map) <- as.character(parse(text = replacements))
-
+  
     # convert to list
     map <- as.list(map)
-
+  
     # remap strings in object
     remapped <- renv_json_read_remap(json, map)
-
+  
     # evaluate
     eval(remapped, envir = baseenv())
-
+  
   }
-
+  
   renv_json_read_remap <- function(json, map) {
-
+  
     # fix names
     if (!is.null(names(json))) {
       lhs <- match(names(json), names(map), nomatch = 0L)
       rhs <- match(names(map), names(json), nomatch = 0L)
       names(json)[rhs] <- map[lhs]
     }
-
+  
     # fix values
     if (is.character(json))
       return(map[[json]] %||% json)
-
+  
     # handle true, false, null
     if (is.name(json)) {
       text <- as.character(json)
@@ -1188,16 +1188,16 @@ local({
       else if (text == "null")
         return(NULL)
     }
-
+  
     # recurse
     if (is.recursive(json)) {
       for (i in seq_along(json)) {
         json[i] <- list(renv_json_read_remap(json[[i]], map))
       }
     }
-
+  
     json
-
+  
   }
 
   # load the renv profile, if any

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -97,24 +97,24 @@ local({
   if ("renv" %in% loadedNamespaces())
     unloadNamespace("renv")
 
-  # load bootstrap tools   
+  # load bootstrap tools
   `%||%` <- function(x, y) {
     if (is.null(x)) y else x
   }
-  
+
   catf <- function(fmt, ..., appendLF = TRUE) {
-  
+
     quiet <- getOption("renv.bootstrap.quiet", default = FALSE)
     if (quiet)
       return(invisible())
-  
+
     msg <- sprintf(fmt, ...)
     cat(msg, file = stdout(), sep = if (appendLF) "\n" else "")
-  
+
     invisible(msg)
-  
+
   }
-  
+
   header <- function(label,
                      ...,
                      prefix = "#",
@@ -125,37 +125,37 @@ local({
     n <- max(n - nchar(label) - nchar(prefix) - 2L, 8L)
     if (n <= 0)
       return(paste(prefix, label))
-  
+
     tail <- paste(rep.int(suffix, n), collapse = "")
     paste0(prefix, " ", label, " ", tail)
-  
+
   }
-  
+
   heredoc <- function(text, leave = 0) {
-  
+
     # remove leading, trailing whitespace
     trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
-  
+
     # split into lines
     lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
-  
+
     # compute common indent
     indent <- regexpr("[^[:space:]]", lines)
     common <- min(setdiff(indent, -1L)) - leave
     paste(substring(lines, common), collapse = "\n")
-  
+
   }
-  
+
   startswith <- function(string, prefix) {
     substring(string, 1, nchar(prefix)) == prefix
   }
-  
+
   bootstrap <- function(version, library) {
-  
+
     friendly <- renv_bootstrap_version_friendly(version)
     section <- header(sprintf("Bootstrapping renv %s", friendly))
     catf(section)
-  
+
     # attempt to download renv
     catf("- Downloading renv ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -167,7 +167,7 @@ local({
     )
     catf("OK")
     on.exit(unlink(tarball), add = TRUE)
-  
+
     # now attempt to install
     catf("- Installing renv  ... ", appendLF = FALSE)
     withCallingHandlers(
@@ -178,174 +178,174 @@ local({
       }
     )
     catf("OK")
-  
+
     # add empty line to break up bootstrapping from normal output
     catf("")
-  
+
     return(invisible())
   }
-  
+
   renv_bootstrap_tests_running <- function() {
     getOption("renv.tests.running", default = FALSE)
   }
-  
+
   renv_bootstrap_repos <- function() {
-  
+
     # get CRAN repository
     cran <- getOption("renv.repos.cran", "https://cloud.r-project.org")
-  
+
     # check for repos override
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
     if (!is.na(repos)) {
-  
+
       # check for RSPM; if set, use a fallback repository for renv
       rspm <- Sys.getenv("RSPM", unset = NA)
       if (identical(rspm, repos))
         repos <- c(RSPM = rspm, CRAN = cran)
-  
+
       return(repos)
-  
+
     }
-  
+
     # check for lockfile repositories
     repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
     if (!inherits(repos, "error") && length(repos))
       return(repos)
-  
+
     # retrieve current repos
     repos <- getOption("repos")
-  
+
     # ensure @CRAN@ entries are resolved
     repos[repos == "@CRAN@"] <- cran
-  
+
     # add in renv.bootstrap.repos if set
     default <- c(FALLBACK = "https://cloud.r-project.org")
     extra <- getOption("renv.bootstrap.repos", default = default)
     repos <- c(repos, extra)
-  
+
     # remove duplicates that might've snuck in
     dupes <- duplicated(repos) | duplicated(names(repos))
     repos[!dupes]
-  
+
   }
-  
+
   renv_bootstrap_repos_lockfile <- function() {
-  
+
     lockpath <- Sys.getenv("RENV_PATHS_LOCKFILE", unset = "renv.lock")
     if (!file.exists(lockpath))
       return(NULL)
-  
+
     lockfile <- tryCatch(renv_json_read(lockpath), error = identity)
     if (inherits(lockfile, "error")) {
       warning(lockfile)
       return(NULL)
     }
-  
+
     repos <- lockfile$R$Repositories
     if (length(repos) == 0)
       return(NULL)
-  
+
     keys <- vapply(repos, `[[`, "Name", FUN.VALUE = character(1))
     vals <- vapply(repos, `[[`, "URL", FUN.VALUE = character(1))
     names(vals) <- keys
-  
+
     return(vals)
-  
+
   }
-  
+
   renv_bootstrap_download <- function(version) {
-  
+
     sha <- attr(version, "sha", exact = TRUE)
-  
+
     methods <- if (!is.null(sha)) {
-  
+
       # attempting to bootstrap a development version of renv
       c(
         function() renv_bootstrap_download_tarball(sha),
         function() renv_bootstrap_download_github(sha)
       )
-  
+
     } else {
-  
+
       # attempting to bootstrap a release version of renv
       c(
         function() renv_bootstrap_download_tarball(version),
         function() renv_bootstrap_download_cran_latest(version),
         function() renv_bootstrap_download_cran_archive(version)
       )
-  
+
     }
-  
+
     for (method in methods) {
       path <- tryCatch(method(), error = identity)
       if (is.character(path) && file.exists(path))
         return(path)
     }
-  
+
     stop("All download methods failed")
-  
+
   }
-  
+
   renv_bootstrap_download_impl <- function(url, destfile) {
-  
+
     mode <- "wb"
-  
+
     # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
     fixup <-
       Sys.info()[["sysname"]] == "Windows" &&
       substring(url, 1L, 5L) == "file:"
-  
+
     if (fixup)
       mode <- "w+b"
-  
+
     args <- list(
       url      = url,
       destfile = destfile,
       mode     = mode,
       quiet    = TRUE
     )
-  
+
     if ("headers" %in% names(formals(utils::download.file)))
       args$headers <- renv_bootstrap_download_custom_headers(url)
-  
+
     do.call(utils::download.file, args)
-  
+
   }
-  
+
   renv_bootstrap_download_custom_headers <- function(url) {
-  
+
     headers <- getOption("renv.download.headers")
     if (is.null(headers))
       return(character())
-  
+
     if (!is.function(headers))
       stopf("'renv.download.headers' is not a function")
-  
+
     headers <- headers(url)
     if (length(headers) == 0L)
       return(character())
-  
+
     if (is.list(headers))
       headers <- unlist(headers, recursive = FALSE, use.names = TRUE)
-  
+
     ok <-
       is.character(headers) &&
       is.character(names(headers)) &&
       all(nzchar(names(headers)))
-  
+
     if (!ok)
       stop("invocation of 'renv.download.headers' did not return a named character vector")
-  
+
     headers
-  
+
   }
-  
+
   renv_bootstrap_download_cran_latest <- function(version) {
-  
+
     spec <- renv_bootstrap_download_cran_latest_find(version)
     type  <- spec$type
     repos <- spec$repos
-  
+
     baseurl <- utils::contrib.url(repos = repos, type = type)
     ext <- if (identical(type, "source"))
       ".tar.gz"
@@ -355,36 +355,36 @@ local({
       ".tgz"
     name <- sprintf("renv_%s%s", version, ext)
     url <- paste(baseurl, name, sep = "/")
-  
+
     destfile <- file.path(tempdir(), name)
     status <- tryCatch(
       renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
-  
+
     if (inherits(status, "condition"))
       return(FALSE)
-  
+
     # report success and return
     destfile
-  
+
   }
-  
+
   renv_bootstrap_download_cran_latest_find <- function(version) {
-  
+
     # check whether binaries are supported on this system
     binary <-
       getOption("renv.bootstrap.binary", default = TRUE) &&
       !identical(.Platform$pkgType, "source") &&
       !identical(getOption("pkgType"), "source") &&
       Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
-  
+
     types <- c(if (binary) "binary", "source")
-  
+
     # iterate over types + repositories
     for (type in types) {
       for (repos in renv_bootstrap_repos()) {
-  
+
         # retrieve package database
         db <- tryCatch(
           as.data.frame(
@@ -393,89 +393,89 @@ local({
           ),
           error = identity
         )
-  
+
         if (inherits(db, "error"))
           next
-  
+
         # check for compatible entry
         entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
         if (nrow(entry) == 0)
           next
-  
+
         # found it; return spec to caller
         spec <- list(entry = entry, type = type, repos = repos)
         return(spec)
-  
+
       }
     }
-  
+
     # if we got here, we failed to find renv
     fmt <- "renv %s is not available from your declared package repositories"
     stop(sprintf(fmt, version))
-  
+
   }
-  
+
   renv_bootstrap_download_cran_archive <- function(version) {
-  
+
     name <- sprintf("renv_%s.tar.gz", version)
     repos <- renv_bootstrap_repos()
     urls <- file.path(repos, "src/contrib/Archive/renv", name)
     destfile <- file.path(tempdir(), name)
-  
+
     for (url in urls) {
-  
+
       status <- tryCatch(
         renv_bootstrap_download_impl(url, destfile),
         condition = identity
       )
-  
+
       if (identical(status, 0L))
         return(destfile)
-  
+
     }
-  
+
     return(FALSE)
-  
+
   }
-  
+
   renv_bootstrap_download_tarball <- function(version) {
-  
+
     # if the user has provided the path to a tarball via
     # an environment variable, then use it
     tarball <- Sys.getenv("RENV_BOOTSTRAP_TARBALL", unset = NA)
     if (is.na(tarball))
       return()
-  
+
     # allow directories
     if (dir.exists(tarball)) {
       name <- sprintf("renv_%s.tar.gz", version)
       tarball <- file.path(tarball, name)
     }
-  
+
     # bail if it doesn't exist
     if (!file.exists(tarball)) {
-  
+
       # let the user know we weren't able to honour their request
       fmt <- "- RENV_BOOTSTRAP_TARBALL is set (%s) but does not exist."
       msg <- sprintf(fmt, tarball)
       warning(msg)
-  
+
       # bail
       return()
-  
+
     }
-  
+
     catf("- Using local tarball '%s'.", tarball)
     tarball
-  
+
   }
-  
+
   renv_bootstrap_download_github <- function(version) {
-  
+
     enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
     if (!identical(enabled, "TRUE"))
       return(FALSE)
-  
+
     # prepare download options
     pat <- Sys.getenv("GITHUB_PAT")
     if (nzchar(Sys.which("curl")) && nzchar(pat)) {
@@ -491,25 +491,25 @@ local({
       options(download.file.method = "wget", download.file.extra = extra)
       on.exit(do.call(base::options, saved), add = TRUE)
     }
-  
+
     url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
     name <- sprintf("renv_%s.tar.gz", version)
     destfile <- file.path(tempdir(), name)
-  
+
     status <- tryCatch(
       renv_bootstrap_download_impl(url, destfile),
       condition = identity
     )
-  
+
     if (!identical(status, 0L))
       return(FALSE)
-  
+
     renv_bootstrap_download_augment(destfile)
-  
+
     return(destfile)
-  
+
   }
-  
+
   # Add Sha to DESCRIPTION. This is stop gap until #890, after which we
   # can use renv::install() to fully capture metadata.
   renv_bootstrap_download_augment <- function(destfile) {
@@ -517,13 +517,13 @@ local({
     if (is.null(sha)) {
       return()
     }
-  
+
     # Untar
     tempdir <- tempfile("renv-github-")
     on.exit(unlink(tempdir, recursive = TRUE), add = TRUE)
     untar(destfile, exdir = tempdir)
     pkgdir <- dir(tempdir, full.names = TRUE)[[1]]
-  
+
     # Modify description
     desc_path <- file.path(pkgdir, "DESCRIPTION")
     desc_lines <- readLines(desc_path)
@@ -537,173 +537,173 @@ local({
       paste("RemoteSha: ", sha)
     )
     writeLines(c(desc_lines[desc_lines != ""], remotes_fields), con = desc_path)
-  
+
     # Re-tar
     local({
       old <- setwd(tempdir)
       on.exit(setwd(old), add = TRUE)
-  
+
       tar(destfile, compression = "gzip")
     })
     invisible()
   }
-  
+
   # Extract the commit hash from a git archive. Git archives include the SHA1
   # hash as the comment field of the tarball pax extended header
   # (see https://www.kernel.org/pub/software/scm/git/docs/git-archive.html)
   # For GitHub archives this should be the first header after the default one
   # (512 byte) header.
   renv_bootstrap_git_extract_sha1_tar <- function(bundle) {
-  
+
     # open the bundle for reading
     # We use gzcon for everything because (from ?gzcon)
     # > Reading from a connection which does not supply a 'gzip' magic
     # > header is equivalent to reading from the original connection
     conn <- gzcon(file(bundle, open = "rb", raw = TRUE))
     on.exit(close(conn))
-  
+
     # The default pax header is 512 bytes long and the first pax extended header
     # with the comment should be 51 bytes long
     # `52 comment=` (11 chars) + 40 byte SHA1 hash
     len <- 0x200 + 0x33
     res <- rawToChar(readBin(conn, "raw", n = len)[0x201:len])
-  
+
     if (grepl("^52 comment=", res)) {
       sub("52 comment=", "", res)
     } else {
       NULL
     }
   }
-  
+
   renv_bootstrap_install <- function(version, tarball, library) {
-  
+
     # attempt to install it into project library
     dir.create(library, showWarnings = FALSE, recursive = TRUE)
     output <- renv_bootstrap_install_impl(library, tarball)
-  
+
     # check for successful install
     status <- attr(output, "status")
     if (is.null(status) || identical(status, 0L))
       return(status)
-  
+
     # an error occurred; report it
     header <- "installation of renv failed"
     lines <- paste(rep.int("=", nchar(header)), collapse = "")
     text <- paste(c(header, lines, output), collapse = "\n")
     stop(text)
-  
+
   }
-  
+
   renv_bootstrap_install_impl <- function(library, tarball) {
-  
+
     # invoke using system2 so we can capture and report output
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
     R <- file.path(bin, exe)
-  
+
     args <- c(
       "--vanilla", "CMD", "INSTALL", "--no-multiarch",
       "-l", shQuote(path.expand(library)),
       shQuote(path.expand(tarball))
     )
-  
+
     system2(R, args, stdout = TRUE, stderr = TRUE)
-  
+
   }
-  
+
   renv_bootstrap_platform_prefix <- function() {
-  
+
     # construct version prefix
     version <- paste(R.version$major, R.version$minor, sep = ".")
     prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
-  
+
     # include SVN revision for development versions of R
     # (to avoid sharing platform-specific artefacts with released versions of R)
     devel <-
       identical(R.version[["status"]],   "Under development (unstable)") ||
       identical(R.version[["nickname"]], "Unsuffered Consequences")
-  
+
     if (devel)
       prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
-  
+
     # build list of path components
     components <- c(prefix, R.version$platform)
-  
+
     # include prefix if provided by user
     prefix <- renv_bootstrap_platform_prefix_impl()
     if (!is.na(prefix) && nzchar(prefix))
       components <- c(prefix, components)
-  
+
     # build prefix
     paste(components, collapse = "/")
-  
+
   }
-  
+
   renv_bootstrap_platform_prefix_impl <- function() {
-  
+
     # if an explicit prefix has been supplied, use it
     prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
     if (!is.na(prefix))
       return(prefix)
-  
+
     # if the user has requested an automatic prefix, generate it
     auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
     if (is.na(auto) && getRversion() >= "4.4.0")
       auto <- "TRUE"
-  
+
     if (auto %in% c("TRUE", "True", "true", "1"))
       return(renv_bootstrap_platform_prefix_auto())
-  
+
     # empty string on failure
     ""
-  
+
   }
-  
+
   renv_bootstrap_platform_prefix_auto <- function() {
-  
+
     prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
     if (inherits(prefix, "error") || prefix %in% "unknown") {
-  
+
       msg <- paste(
         "failed to infer current operating system",
         "please file a bug report at https://github.com/rstudio/renv/issues",
         sep = "; "
       )
-  
+
       warning(msg)
-  
+
     }
-  
+
     prefix
-  
+
   }
-  
+
   renv_bootstrap_platform_os <- function() {
-  
+
     sysinfo <- Sys.info()
     sysname <- sysinfo[["sysname"]]
-  
+
     # handle Windows + macOS up front
     if (sysname == "Windows")
       return("windows")
     else if (sysname == "Darwin")
       return("macos")
-  
+
     # check for os-release files
     for (file in c("/etc/os-release", "/usr/lib/os-release"))
       if (file.exists(file))
         return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
-  
+
     # check for redhat-release files
     if (file.exists("/etc/redhat-release"))
       return(renv_bootstrap_platform_os_via_redhat_release())
-  
+
     "unknown"
-  
+
   }
-  
+
   renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
-  
+
     # read /etc/os-release
     release <- utils::read.table(
       file             = file,
@@ -713,13 +713,13 @@ local({
       comment.char     = "#",
       stringsAsFactors = FALSE
     )
-  
+
     vars <- as.list(release$Value)
     names(vars) <- release$Key
-  
+
     # get os name
     os <- tolower(sysinfo[["sysname"]])
-  
+
     # read id
     id <- "unknown"
     for (field in c("ID", "ID_LIKE")) {
@@ -728,7 +728,7 @@ local({
         break
       }
     }
-  
+
     # read version
     version <- "unknown"
     for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
@@ -737,17 +737,17 @@ local({
         break
       }
     }
-  
+
     # join together
     paste(c(os, id, version), collapse = "-")
-  
+
   }
-  
+
   renv_bootstrap_platform_os_via_redhat_release <- function() {
-  
+
     # read /etc/redhat-release
     contents <- readLines("/etc/redhat-release", warn = FALSE)
-  
+
     # infer id
     id <- if (grepl("centos", contents, ignore.case = TRUE))
       "centos"
@@ -755,73 +755,73 @@ local({
       "redhat"
     else
       "unknown"
-  
+
     # try to find a version component (very hacky)
     version <- "unknown"
-  
+
     parts <- strsplit(contents, "[[:space:]]")[[1L]]
     for (part in parts) {
-  
+
       nv <- tryCatch(numeric_version(part), error = identity)
       if (inherits(nv, "error"))
         next
-  
+
       version <- nv[1, 1]
       break
-  
+
     }
-  
+
     paste(c("linux", id, version), collapse = "-")
-  
+
   }
-  
+
   renv_bootstrap_library_root_name <- function(project) {
-  
+
     # use project name as-is if requested
     asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
     if (asis)
       return(basename(project))
-  
+
     # otherwise, disambiguate based on project's path
     id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
     paste(basename(project), id, sep = "-")
-  
+
   }
-  
+
   renv_bootstrap_library_root <- function(project) {
-  
+
     prefix <- renv_bootstrap_profile_prefix()
-  
+
     path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
     if (!is.na(path))
       return(paste(c(path, prefix), collapse = "/"))
-  
+
     path <- renv_bootstrap_library_root_impl(project)
     if (!is.null(path)) {
       name <- renv_bootstrap_library_root_name(project)
       return(paste(c(path, prefix, name), collapse = "/"))
     }
-  
+
     renv_bootstrap_paths_renv("library", project = project)
-  
+
   }
-  
+
   renv_bootstrap_library_root_impl <- function(project) {
-  
+
     root <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
     if (!is.na(root))
       return(root)
-  
+
     type <- renv_bootstrap_project_type(project)
     if (identical(type, "package")) {
       userdir <- renv_bootstrap_user_dir()
       return(file.path(userdir, "library"))
     }
-  
+
   }
-  
+
   renv_bootstrap_validate_version <- function(version, description = NULL) {
-  
+
     # resolve description file
     #
     # avoid passing lib.loc to `packageDescription()` below, since R will
@@ -829,17 +829,17 @@ local({
     # this function should only be called after 'renv' is loaded
     # https://github.com/rstudio/renv/issues/1625
     description <- description %||% packageDescription("renv")
-  
+
     # check whether requested version 'version' matches loaded version of renv
     sha <- attr(version, "sha", exact = TRUE)
     valid <- if (!is.null(sha))
       renv_bootstrap_validate_version_dev(sha, description)
     else
       renv_bootstrap_validate_version_release(version, description)
-  
+
     if (valid)
       return(TRUE)
-  
+
     # the loaded version of renv doesn't match the requested version;
     # give the user instructions on how to proceed
     dev <- identical(description[["RemoteType"]], "github")
@@ -847,103 +847,103 @@ local({
       paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
     else
       paste("renv", description[["Version"]], sep = "@")
-  
+
     # display both loaded version + sha if available
     friendly <- renv_bootstrap_version_friendly(
       version = description[["Version"]],
       sha     = if (dev) description[["RemoteSha"]]
     )
-  
+
     fmt <- heredoc("
       renv %1$s was loaded from project library, but this project is configured to use renv %2$s.
       - Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.
       - Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.
     ")
     catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
-  
+
     FALSE
-  
+
   }
-  
+
   renv_bootstrap_validate_version_dev <- function(version, description) {
     expected <- description[["RemoteSha"]]
     is.character(expected) && startswith(expected, version)
   }
-  
+
   renv_bootstrap_validate_version_release <- function(version, description) {
     expected <- description[["Version"]]
     is.character(expected) && identical(expected, version)
   }
-  
+
   renv_bootstrap_hash_text <- function(text) {
-  
+
     hashfile <- tempfile("renv-hash-")
     on.exit(unlink(hashfile), add = TRUE)
-  
+
     writeLines(text, con = hashfile)
     tools::md5sum(hashfile)
-  
+
   }
-  
+
   renv_bootstrap_load <- function(project, libpath, version) {
-  
+
     # try to load renv from the project library
     if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
       return(FALSE)
-  
+
     # warn if the version of renv loaded does not match
     renv_bootstrap_validate_version(version)
-  
+
     # execute renv load hooks, if any
     hooks <- getHook("renv::autoload")
     for (hook in hooks)
       if (is.function(hook))
         tryCatch(hook(), error = warnify)
-  
+
     # load the project
     renv::load(project)
-  
+
     TRUE
-  
+
   }
-  
+
   renv_bootstrap_profile_load <- function(project) {
-  
+
     # if RENV_PROFILE is already set, just use that
     profile <- Sys.getenv("RENV_PROFILE", unset = NA)
     if (!is.na(profile) && nzchar(profile))
       return(profile)
-  
+
     # check for a profile file (nothing to do if it doesn't exist)
     path <- renv_bootstrap_paths_renv("profile", profile = FALSE, project = project)
     if (!file.exists(path))
       return(NULL)
-  
+
     # read the profile, and set it if it exists
     contents <- readLines(path, warn = FALSE)
     if (length(contents) == 0L)
       return(NULL)
-  
+
     # set RENV_PROFILE
     profile <- contents[[1L]]
     if (!profile %in% c("", "default"))
       Sys.setenv(RENV_PROFILE = profile)
-  
+
     profile
-  
+
   }
-  
+
   renv_bootstrap_profile_prefix <- function() {
     profile <- renv_bootstrap_profile_get()
     if (!is.null(profile))
       return(file.path("profiles", profile, "renv"))
   }
-  
+
   renv_bootstrap_profile_get <- function() {
     profile <- Sys.getenv("RENV_PROFILE", unset = "")
     renv_bootstrap_profile_normalize(profile)
   }
-  
+
   renv_bootstrap_profile_set <- function(profile) {
     profile <- renv_bootstrap_profile_normalize(profile)
     if (is.null(profile))
@@ -951,25 +951,25 @@ local({
     else
       Sys.setenv(RENV_PROFILE = profile)
   }
-  
+
   renv_bootstrap_profile_normalize <- function(profile) {
-  
+
     if (is.null(profile) || profile %in% c("", "default"))
       return(NULL)
-  
+
     profile
-  
+
   }
-  
+
   renv_bootstrap_path_absolute <- function(path) {
-  
+
     substr(path, 1L, 1L) %in% c("~", "/", "\\") || (
       substr(path, 1L, 1L) %in% c(letters, LETTERS) &&
       substr(path, 2L, 3L) %in% c(":/", ":\\")
     )
-  
+
   }
-  
+
   renv_bootstrap_paths_renv <- function(..., profile = TRUE, project = NULL) {
     renv <- Sys.getenv("RENV_PATHS_RENV", unset = "renv")
     root <- if (renv_bootstrap_path_absolute(renv)) NULL else project
@@ -977,50 +977,50 @@ local({
     components <- c(root, renv, prefix, ...)
     paste(components, collapse = "/")
   }
-  
+
   renv_bootstrap_project_type <- function(path) {
-  
+
     descpath <- file.path(path, "DESCRIPTION")
     if (!file.exists(descpath))
       return("unknown")
-  
+
     desc <- tryCatch(
       read.dcf(descpath, all = TRUE),
       error = identity
     )
-  
+
     if (inherits(desc, "error"))
       return("unknown")
-  
+
     type <- desc$Type
     if (!is.null(type))
       return(tolower(type))
-  
+
     package <- desc$Package
     if (!is.null(package))
       return("package")
-  
+
     "unknown"
-  
+
   }
-  
+
   renv_bootstrap_user_dir <- function() {
     dir <- renv_bootstrap_user_dir_impl()
     path.expand(chartr("\\", "/", dir))
   }
-  
+
   renv_bootstrap_user_dir_impl <- function() {
-  
+
     # use local override if set
     override <- getOption("renv.userdir.override")
     if (!is.null(override))
       return(override)
-  
+
     # use R_user_dir if available
     tools <- asNamespace("tools")
     if (is.function(tools$R_user_dir))
       return(tools$R_user_dir("renv", "cache"))
-  
+
     # try using our own backfill for older versions of R
     envvars <- c("R_USER_CACHE_DIR", "XDG_CACHE_HOME")
     for (envvar in envvars) {
@@ -1028,7 +1028,7 @@ local({
       if (!is.na(root))
         return(file.path(root, "R/renv"))
     }
-  
+
     # use platform-specific default fallbacks
     if (Sys.info()[["sysname"]] == "Windows")
       file.path(Sys.getenv("LOCALAPPDATA"), "R/cache/R/renv")
@@ -1036,109 +1036,109 @@ local({
       "~/Library/Caches/org.R-project.R/R/renv"
     else
       "~/.cache/R/renv"
-  
+
   }
-  
+
   renv_bootstrap_version_friendly <- function(version, shafmt = NULL, sha = NULL) {
     sha <- sha %||% attr(version, "sha", exact = TRUE)
     parts <- c(version, sprintf(shafmt %||% " [sha: %s]", substring(sha, 1L, 7L)))
     paste(parts, collapse = "")
   }
-  
+
   renv_bootstrap_exec <- function(project, libpath, version) {
     if (!renv_bootstrap_load(project, libpath, version))
       renv_bootstrap_run(version, libpath)
   }
-  
+
   renv_bootstrap_run <- function(version, libpath) {
-  
+
     # perform bootstrap
     bootstrap(version, libpath)
-  
+
     # exit early if we're just testing bootstrap
     if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
       return(TRUE)
-  
+
     # try again to load
     if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
       return(renv::load(project = getwd()))
     }
-  
+
     # failed to download or load renv; warn the user
     msg <- c(
       "Failed to find an renv installation: the project will not be loaded.",
       "Use `renv::activate()` to re-initialize the project."
     )
-  
+
     warning(paste(msg, collapse = "\n"), call. = FALSE)
-  
+
   }
-  
+
   renv_json_read <- function(file = NULL, text = NULL) {
-  
+
     jlerr <- NULL
-  
+
     # if jsonlite is loaded, use that instead
     if ("jsonlite" %in% loadedNamespaces()) {
-  
+
       json <- tryCatch(renv_json_read_jsonlite(file, text), error = identity)
       if (!inherits(json, "error"))
         return(json)
-  
+
       jlerr <- json
-  
+
     }
-  
+
     # otherwise, fall back to the default JSON reader
     json <- tryCatch(renv_json_read_default(file, text), error = identity)
     if (!inherits(json, "error"))
       return(json)
-  
+
     # report an error
     if (!is.null(jlerr))
       stop(jlerr)
     else
       stop(json)
-  
+
   }
-  
+
   renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
     text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
   }
-  
+
   renv_json_read_default <- function(file = NULL, text = NULL) {
-  
+
     # find strings in the JSON
     text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
-  
+
     # if any are found, replace them with placeholders
     replaced <- text
     strings <- character()
     replacements <- character()
-  
+
     if (!identical(c(locs), -1L)) {
-  
+
       # get the string values
       starts <- locs
       ends <- locs + attr(locs, "match.length") - 1L
       strings <- substring(text, starts, ends)
-  
+
       # only keep those requiring escaping
       strings <- grep("[[\\]{}:]", strings, perl = TRUE, value = TRUE)
-  
+
       # compute replacements
       replacements <- sprintf('"\032%i\032"', seq_along(strings))
-  
+
       # replace the strings
       mapply(function(string, replacement) {
         replaced <<- sub(string, replacement, replaced, fixed = TRUE)
       }, strings, replacements)
-  
+
     }
-  
+
     # transform the JSON into something the R parser understands
     transformed <- replaced
     transformed <- gsub("{}", "`names<-`(list(), character())", transformed, fixed = TRUE)
@@ -1146,38 +1146,38 @@ local({
     transformed <- gsub("[]}]", ")", transformed, perl = TRUE)
     transformed <- gsub(":", "=", transformed, fixed = TRUE)
     text <- paste(transformed, collapse = "\n")
-  
+
     # parse it
     json <- parse(text = text, keep.source = FALSE, srcfile = NULL)[[1L]]
-  
+
     # construct map between source strings, replaced strings
     map <- as.character(parse(text = strings))
     names(map) <- as.character(parse(text = replacements))
-  
+
     # convert to list
     map <- as.list(map)
-  
+
     # remap strings in object
     remapped <- renv_json_read_remap(json, map)
-  
+
     # evaluate
     eval(remapped, envir = baseenv())
-  
+
   }
-  
+
   renv_json_read_remap <- function(json, map) {
-  
+
     # fix names
     if (!is.null(names(json))) {
       lhs <- match(names(json), names(map), nomatch = 0L)
       rhs <- match(names(map), names(json), nomatch = 0L)
       names(json)[rhs] <- map[lhs]
     }
-  
+
     # fix values
     if (is.character(json))
       return(map[[json]] %||% json)
-  
+
     # handle true, false, null
     if (is.name(json)) {
       text <- as.character(json)
@@ -1188,16 +1188,16 @@ local({
       else if (text == "null")
         return(NULL)
     }
-  
+
     # recurse
     if (is.recursive(json)) {
       for (i in seq_along(json)) {
         json[i] <- list(renv_json_read_remap(json[[i]], map))
       }
     }
-  
+
     json
-  
+
   }
 
   # load the renv profile, if any


### PR DESCRIPTION
# Description
Minor updates for Q3 reporting

## Motivation and Context
Wanted the renv::status() output documented in our knitted output as well as automating the use of the renv with activate command (not sure this is really needed).  Also set the default output path to the repo directory - just manually copy and paste to the publishing location.

## Breaking Changes
No

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` or `.runsettings` to
demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the
provided `examples/*` or `.runsettings`
